### PR TITLE
Bind-mount repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
       id: install_deps
       with:
         image_additional_mb: 1500
+        bind_mount_repository: true
         base_image: ${{ matrix.base_image }}
         commands: |
           chmod +x ${{matrix.script}}


### PR DESCRIPTION
Means we dont accidentally include this repo in built images