### PR TITLE
updated OPi5 and OPi5+base_image to v1.33

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
             base_image: https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2023-12-11/2023-12-11-raspios-bookworm-arm64-lite.img.xz
           - name: opi5
             script: ./install_opi5.sh
-            base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v1.30/ubuntu-22.04.3-preinstalled-server-arm64-orangepi-5.img.xz
+            base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v1.33/ubuntu-22.04.3-preinstalled-server-arm64-orangepi-5.img.xz
           - name: opi5plus
             script: ./install_opi5.sh
-            base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v1.30/ubuntu-22.04.3-preinstalled-server-arm64-orangepi-5-plus.img.xz
+            base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v1.33/ubuntu-22.04.3-preinstalled-server-arm64-orangepi-5-plus.img.xz
 
     name: "Build for ${{ matrix.name }}"
 


### PR DESCRIPTION
Limited testing indicates that the OPi image v1.33 is more stable and may correct the problem with Object Detection pipelines crashing.