### PR TITLE
faster boot for opi5

### DIFF
--- a/install_opi5.sh
+++ b/install_opi5.sh
@@ -34,6 +34,10 @@ apt-get install -y network-manager net-tools libatomic1
 # mrcal stuff
 apt-get install -y libcholmod3 liblapack3 libsuitesparseconfig5
 
+
+systemctl disable ap6275p-bluetooth
+touch /etc/cloud/cloud-init.disabled
+
 cat > /etc/netplan/00-default-nm-renderer.yaml <<EOF
 network:
   renderer: NetworkManager


### PR DESCRIPTION
add `systemctl disable ap6275p-bluetooth` and `touch /etc/cloud/cloud-init.disabled` 
Fixes https://github.com/PhotonVision/photonvision/issues/1259