### PR TITLE
Don't ask for password on sudo for OPi5 images

### DIFF
--- a/install_opi5.sh
+++ b/install_opi5.sh
@@ -8,6 +8,9 @@ else
     usermod -a -G sudo pi
     mkdir /home/pi
     chown -R pi /home/pi
+
+    echo 'pi ALL=(ALL) NOPASSWD: ALL' | tee -a /etc/sudoers.d/010_pi-nopasswd >/dev/null
+    chmod 0440 /etc/sudoers.d/010_pi-nopasswd
 fi
 echo "pi:raspberry" | chpasswd
 


### PR DESCRIPTION
The photonvision dev tooling expects the 'pi' user to not ask for password on sudo when running `./gradlew deploy -PArchOverride=linuxarm64`, since this is the default on RPI OS.

We should do the same here so that gradle behaves on Orange Pi 5 devices as well.