### PR TITLE
Remove large folders of firmware that (probably) isn't needed

### DIFF
--- a/install_opi5.sh
+++ b/install_opi5.sh
@@ -31,6 +31,13 @@ apt-get --yes --quiet autoremove
 after=$(df --output=used / | tail -n1)
 freed=$(( before - after ))
 
+# remove firmware that (probably) isn't needed
+rm -rf /usr/lib/firmware/mrvl
+rm -rf /usr/lib/firmware/mellanox
+rm -rf /usr/lib/firmware/nvidia
+rm -rf /usr/lib/firmware/intel
+rm -rf /usr/lib/firmware/amdgpu
+
 echo "Freed up $freed KiB"
 
 # run Photonvision install script


### PR DESCRIPTION
There are a lot of firmware files included in the OrangePi images that are for hardware that isn't likely to be used with PhotonVision. 

Here are the largest directories:
```
pi@photonvision:~$ du -sch /usr/lib/firmware/* | sort -rh | head
588M    total
78M     /usr/lib/firmware/mrvl
78M     /usr/lib/firmware/mellanox
74M     /usr/lib/firmware/6.1.0-1025-rockchip
59M     /usr/lib/firmware/qcom
41M     /usr/lib/firmware/nvidia
28M     /usr/lib/firmware/intel
23M     /usr/lib/firmware/amdgpu
19M     /usr/lib/firmware/rkwifi
15M     /usr/lib/firmware/mediatek
```
