### PR TITLE
Exit install script if run on systemcore

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,11 @@ Syntax: sudo ./install.sh [options]
 EOF
 }
 
+# Exit with message if attempting to run on SystemCore
+if grep -iq "systemcore" /etc/os-release; then
+  die "This install script does not work on Systemcore."
+fi
+
 INSTALL_NETWORK_MANAGER="ask"
 VERSION="latest"
 


### PR DESCRIPTION
The install script requires 'apt' and other libraries and isn't intended for use on Systemcore. This PR detects if the script is running on system core by checking `/etc/os-release', which will include the word "systemcore" as of alpha 3 per https://github.com/wpilibsuite/SystemCoreTesting/issues/85.