### PR TITLE
Fix --list-versions in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ install_if_missing() {
 get_versions() {
   PHOTON_VISION_RELEASES="$(wget -qO- https://api.github.com/repos/photonvision/photonvision/releases?per_page=$1)"
 
-  PHOTON_VISION_VERSIONS=$(get_photonvision_releases | \
+  PHOTON_VISION_VERSIONS=$(echo "$PHOTON_VISION_RELEASES" | \
     sed -En 's/\"tag_name\": \"(.+)\",/\1/p' | \
     sed 's/^[[:space:]]*//'
   )


### PR DESCRIPTION
The code for listing versions was rewritten in #49, but a call to a deleted function was left in by mistake. This PR corrects that error.