### PR TITLE
Fix mount script for use in monorepo

### DIFF
--- a/mount_rubikpi3.sh
+++ b/mount_rubikpi3.sh
@@ -49,7 +49,7 @@ ROOTFS_IMG=""
 
 # If not found, use the largest .img.xz file
 ROOTFS_IMG="${ROOTFS_IMG:-$(find . -type f \( -name '*.img.xz' -o -name '*.img' \) -exec ls -s {} + 2>/dev/null | sort -rn | head -n1 | awk '{print $2}')}"
-[ -n "$ROOTFS_IMG" ] && echo "Using largest .img.xz file as rootfs: $ROOTFS_IMG"
+[ -n "$ROOTFS_IMG" ] && echo "Using largest .img.xz or .img file as rootfs: $ROOTFS_IMG"
 
 if [ -z "$ROOTFS_IMG" ] || [ ! -f "$ROOTFS_IMG" ]; then
   echo "Error: Could not find a suitable rootfs image file"


### PR DESCRIPTION
The previous script checked for image files in the current directory. This adds support for checking of subdirectories, which is necessary once we've extracted the files from the tarball into the photonvision_rubikpi3 directory.