### PR TITLE
Smaller expansion for rubikpi3 image

### DIFF
--- a/mount_rubikpi3.sh
+++ b/mount_rubikpi3.sh
@@ -113,9 +113,9 @@ if [ "$ImgType" == "Canonical" ]; then
   echo "=== Unmounting for expansion ==="
   sudo umount ./rootfs
 
-  # Expand the image by 4GB (reduced from 10GB to fit GitHub Actions disk space)
-  echo "=== Expanding image by 4GB ==="
-  dd if=/dev/zero bs=1M count=4096 >> "$ROOTFS_IMG"
+  # Expand the image by 2GB (reduced from 10GB to fit GitHub Actions disk space)
+  echo "=== Expanding image by 2GB ==="
+  dd if=/dev/zero bs=1M count=2048 >> "$ROOTFS_IMG"
 
   # Remount after expansion
   echo "=== Remounting after expansion ==="


### PR DESCRIPTION
Reduce expansion from 4 Gigabytes to 2 Gigabytes to save space.