### PR TITLE
Remove gh-action-releaser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,8 @@ jobs:
       # Download literally every single artifact
       - uses: actions/download-artifact@v4.1.8
       - run: find
-      # Push to dev release, this will also push to tags using semantic versioning
+      # Push to dev release and/or to a real release if tagged using semantic versioning
+      # See https://github.com/pyTooling/Actions/tree/dev/releaser
       - uses: pyTooling/Actions/releaser@v1.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove gh-action releaser as the [pytooling releaser](https://github.com/pyTooling/Actions/tree/dev/releaser) will also push assets for any tags created using semver, making the gh-action one unnecessary:

From [the readme](https://github.com/pyTooling/Actions/tree/dev/releaser)

```
Releaser allows to keep a GitHub Release of type pre-release and its artifacts up to date with latest builds 
[...]
Furthermore, when any [semver](https://semver.org/) compilant tagged commit is pushed, Releaser can create a release and upload assets.
```