### PR TITLE
Remove jammy apt source

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -286,16 +286,16 @@ fi
 
 debug ""
 debug "Installing additional math packages"
-if [[ "$DISTRO" = "Ubuntu" && -z $(apt-cache search libcholmod3) ]]; then
-  debug "Adding jammy to list of apt sources"
-  if [[ -z $TEST ]]; then
-    if [[ "$ARCH" = "x86_64" ]]; then
-      add-apt-repository -y -S 'deb http://security.ubuntu.com/ubuntu jammy main universe'
-    else 
-      add-apt-repository -y -S 'deb http://ports.ubuntu.com/ubuntu-ports jammy main universe'
-    fi
-  fi
-fi
+# if [[ "$DISTRO" = "Ubuntu" && -z $(apt-cache search libcholmod3) ]]; then
+#   debug "Adding jammy to list of apt sources"
+#   if [[ -z $TEST ]]; then
+#     if [[ "$ARCH" = "x86_64" ]]; then
+#       add-apt-repository -y -S 'deb http://security.ubuntu.com/ubuntu jammy main universe'
+#     else 
+#       add-apt-repository -y -S 'deb http://ports.ubuntu.com/ubuntu-ports jammy main universe'
+#     fi
+#   fi
+# fi
 
 install_if_missing libcholmod3
 install_if_missing liblapack3


### PR DESCRIPTION
We're seeing cases where hitting the jammy apt sources takes forever, see [this action run](https://github.com/PhotonVision/photon-image-modifier/actions/runs/18432734620/job/52522175587#step:4:1334). Thus, we're removing it to see if we actually need it or not.