### PR TITLE
Add pi:raspberry user and delete ubuntu user

### DIFF
--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -7,6 +7,22 @@ echo '=== Current directory: \$(pwd) ==='
 echo '=== Files in current directory: ==='
 ls -la
 
+# Create user pi:raspberry login
+echo "creating pi user"
+useradd pi -m -b /home -s /bin/bash
+usermod -a -G sudo pi
+echo 'pi ALL=(ALL) NOPASSWD: ALL' | tee -a /etc/sudoers.d/010_pi-nopasswd >/dev/null
+chmod 0440 /etc/sudoers.d/010_pi-nopasswd
+
+echo "pi:raspberry" | chpasswd
+
+# Delete ubuntu user
+
+if id "ubuntu" >/dev/null 2>&1; then
+    echo 'removing ubuntu user'
+    deluser --remove-home ubuntu
+fi
+
 REPO_ENTRY="deb http://apt.thundercomm.com/rubik-pi-3/noble ppa main"
 HOST_ENTRY="151.106.120.85 apt.rubikpi.ai"	# TODO: Remove legacy
 


### PR DESCRIPTION
We need to configure the user since the default isn't set to pi:raspberry like most of our other images.