### PR TITLE
Add checkpoint printing for tar command

### DIFF
--- a/mount_rubikpi3.sh
+++ b/mount_rubikpi3.sh
@@ -1,4 +1,3 @@
-# Set variables
 
 base_image=$1
 script=$2
@@ -211,4 +210,5 @@ find photonvision_rubikpi3 -mindepth 1 -type d -empty -delete
 # Set output for later steps
 # Save the rootfs image path for later steps
 echo "rootfs_image=$ROOTFS_IMG" >> $GITHUB_ENV
-tar -I 'xz -T0' -cf --checkpoint photonvision_rubikpi3.tar.xz photonvision_rubikpi3
+tar -I 'xz -T0' -cf photonvision_rubikpi3.tar.xz photonvision_rubikpi3 --checkpoint=10000 --checkpoint-action=echo='%T'
+


### PR DESCRIPTION
It takes a hot minute to actually compress all the files, so it would be nice to be able to get a sense of where we are in that process. This command will print an update every 100 MB, give or take. This isn't very important, just a QoL thing.