### PR TITLE
Fix tarball directory structure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Compress built image
       run: |
-        tar -I 'xz -T0' -cf photonvision_rubikpi3.tar.xz ${{ env.image_dir }} --checkpoint=10000 --checkpoint-action=echo='%T'
+        tar -I 'xz -T0' -cf photonvision_rubikpi3.tar.xz photonvision_rubikpi3 --checkpoint=10000 --checkpoint-action=echo='%T'
 
     - uses: actions/upload-artifact@v4.3.4
       with:

--- a/mount_rubikpi3.sh
+++ b/mount_rubikpi3.sh
@@ -206,7 +206,3 @@ mv *.img photonvision_rubikpi3/ 2>/dev/null || true
 find photonvision_rubikpi3 -mindepth 2 -type f -exec mv {} photonvision_rubikpi3/ \;
 # Remove empty subdirectories
 find photonvision_rubikpi3 -mindepth 1 -type d -empty -delete
-
-# Set output for later steps
-# Save the rootfs image path for later steps
-echo "image_dir=$PWD/photonvision_rubikpi3" >> $GITHUB_ENV


### PR DESCRIPTION
Previously, the tarball compressed everything starting at the root of the runner. This fixes the issue so that we only compress the relevant directory.