### PR TITLE
Add user:password note to login text

### DIFF
--- a/files/issue.txt
+++ b/files/issue.txt
@@ -4,15 +4,16 @@
          #################              for the FIRST Robotics Competition. 
        ######        ######   :::       
       #####            ##*::::::::::    To configure PhotonVision, open:
-     #####     :::::::::::::::::::      
-     #### :::::::::::    ###            http://photonvision.local:5800
-     ####                ####           
-    ####                 ####           using a computer on the same network 
-    #### ::              ###            as this device.
+     #####     :::::::::::::::::::      http://photonvision.local:5800
+     #### :::::::::::    ###            using a computer on the same
+     ####                ####           network as this device.
+    ####                 ####            
+    #### ::              ###            Documentation is available at:
      #### :::::::       ####            
-     ####     ::::::::  ####            Documentation is available at: 
+     ####     ::::::::  ####            https://docs.photonvision.org/ 
      #####         ::::::::    :        
-      ######        ####:::::::::       https://docs.photonvision.org/
+      ######        ####:::::::::       SSH Credentials:
        ##################    ::::::     
-         ##############                 The SSH user:password pair for
-           #########                    this device is photon:vision
+         ##############                 The username is photon
+           #########                    The password is vision
+                                        


### PR DESCRIPTION
This adds a note about the SSH username and password to the text that is displayed on the screen when attempting to SSH into the coprocessor.

Discoverability of the user:pass is currently rather low, and this will increase visibility. Generally, this would be ill-advised for security reasons, but in our use case security is a non-issue.