### PR TITLE
Remove pigpio

### DIFF
--- a/files/pigpiod.service
+++ b/files/pigpiod.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Daemon required to control GPIO pins via pigpio
-[Service]
-ExecStart=/usr/bin/pigpiod -l -n 127.0.0.1 -m
-ExecStop=/bin/systemctl kill pigpiod
-Type=forking
-[Install]
-WantedBy=multi-user.target

--- a/install_dev_pi.sh
+++ b/install_dev_pi.sh
@@ -26,18 +26,12 @@ sed -i 's/raspberrypi/photonvision/g' /etc/hosts
 install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
 install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf
 
-# Update pigipio service file to listen locally
-install -v -m 644 files/pigpiod.service /lib/systemd/system/pigpiod.service
-systemctl daemon-reload
-
-# Enable ssh/pigpiod
+# Enable ssh
 systemctl enable ssh
-systemctl enable pigpiod
-
 
 echo "Installing additional things"
 sudo apt-get update
-apt-get install -y pigpiod pigpio device-tree-compiler
+apt-get install -y device-tree-compiler
 apt-get install -y network-manager net-tools
 # libcamera-driver stuff
 apt-get install -y libegl1 libopengl0 libgl1-mesa-dri libgbm1 libegl1-mesa-dev libcamera-dev cmake build-essential libdrm-dev libgbm-dev default-jdk openjdk-17-jdk

--- a/install_limelight.sh
+++ b/install_limelight.sh
@@ -25,13 +25,8 @@ dtc -O dtb limelight/gloworm-dt.dts -o /boot/dt-blob.bin
 install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
 install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf
 
-# Update pigipio service file to listen locally
-install -v -m 644 files/pigpiod.service /lib/systemd/system/pigpiod.service
-systemctl daemon-reload
-
-# Enable ssh/pigpiod
+# Enable ssh
 systemctl enable ssh
-systemctl enable pigpiod
 
 # Remove extra packages too
 echo "Purging extra things"
@@ -40,7 +35,7 @@ apt-get autoremove -y
 
 echo "Installing additional things"
 sudo apt-get update
-apt-get install -y pigpiod pigpio device-tree-compiler
+apt-get install -y device-tree-compiler
 apt-get install -y network-manager net-tools
 # libcamera-driver stuff
 apt-get install -y libegl1 libopengl0 libgl1-mesa-dri libcamera-dev libgbm1

--- a/install_pi.sh
+++ b/install_pi.sh
@@ -26,13 +26,8 @@ sed -i 's/raspberrypi/photonvision/g' /etc/hosts
 install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
 install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf
 
-# Update pigipio service file to listen locally
-install -v -m 644 files/pigpiod.service /lib/systemd/system/pigpiod.service
-systemctl daemon-reload
-
-# Enable ssh/pigpiod
+# Enable ssh
 systemctl enable ssh
-systemctl enable pigpiod
 
 # Remove extra packages too
 echo "Purging extra things"
@@ -41,7 +36,7 @@ apt-get autoremove -y
 
 echo "Installing additional things"
 sudo apt-get update
-apt-get install -y pigpiod pigpio device-tree-compiler
+apt-get install -y device-tree-compiler
 apt-get install -y network-manager net-tools
 # libcamera-driver stuff
 apt-get install -y libegl1 libopengl0 libgl1-mesa-dri libcamera-dev libgbm1


### PR DESCRIPTION
Corresponding to PhotonVision/photonvision#2171, this removes the now-unused `pigpio` dependency from the installation scripts.

closes #63