### PR TITLE
Replace cpufrequtils with CPUFreq sysfs interaction

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -259,20 +259,27 @@ debug "Updated package list."
 
 install_if_missing curl
 install_if_missing avahi-daemon
-install_if_missing cpufrequtils
 install_if_missing libatomic1
 install_if_missing v4l-utils
 install_if_missing sqlite3
 install_if_missing openjdk-17-jre-headless
 install_if_missing usbtop
 
-debug "Setting cpufrequtils to performance mode"
+debug "Adding cpu governor service"
 if [[ -z $TEST ]]; then
-  if [ -f /etc/default/cpufrequtils ]; then
-      sed -i -e 's/^#\?GOVERNOR=.*$/GOVERNOR=performance/' /etc/default/cpufrequtils
-  else
-      echo 'GOVERNOR=performance' > /etc/default/cpufrequtils
-  fi
+  cat > /etc/systemd/system/cpu_governor.service <<EOF
+[Unit]
+Description=Service that sets the cpu frequency governor
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod 644 /etc/systemd/system/cpu_governor.service
+  systemctl enable cpu_governor.service
 fi
 
 if [[ "$INSTALL_NETWORK_MANAGER" == "yes" ]]; then


### PR DESCRIPTION
This removes the `cpufrequtils` package dependency by directly interacting with the Linux CPUFreq sysfs interface to set the frequency policy governor. `cpufrequtils` does not exist in Debian Trixie (13), and I did not find any replacement packages that exist in both Debian 13 and Ubuntu 25.10. However, the sysfs api provided by the Linux kernel seemed sufficient to meet PhotonVision's needs of changing the frequency governor.