### PR TITLE
Better check for ubuntu user in rubik image

### DIFF
--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -19,7 +19,8 @@ echo "pi:raspberry" | chpasswd
 
 # Delete ubuntu user
 
-if grep -q "ubuntu" /etc/passwd; then
+cat /etc/passwd
+if grep  "ubuntu" /etc/passwd; then
     echo 'removing ubuntu user'
     sudo deluser --remove-home ubuntu
 fi


### PR DESCRIPTION
Previously, we checked using `id`, which fails if we're running under a different user (such as root). We now check the `/etc/passwd` file.