### PR TITLE
Set hostname to photonvision on RaspberyPi images

### DIFF
--- a/install_dev_pi.sh
+++ b/install_dev_pi.sh
@@ -18,6 +18,10 @@ chmod +x ./install.sh
 install -m 644 config.txt /boot/
 install -m 644 userconf.txt /boot/
 
+# configure hostname
+echo "photonvision" > /etc/hostname
+sed -i 's/raspberrypi/photonvision/g' /etc/hosts
+
 # Kill wifi and other networking things
 install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
 install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf

--- a/install_pi.sh
+++ b/install_pi.sh
@@ -18,6 +18,10 @@ chmod +x ./install.sh
 install -m 644 config.txt /boot/
 install -m 644 userconf.txt /boot/
 
+# configure hostname
+echo "photonvision" > /etc/hostname
+sed -i 's/raspberrypi/photonvision/g' /etc/hosts
+
 # Kill wifi and other networking things
 install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
 install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf


### PR DESCRIPTION
Update the hostname to 'photonvision' so that RaspberryPi-based systems boot with the right hostname.

Closes #89 