### PR TITLE
Use /boot mounted by photon-image-runner on OPi5

### DIFF
--- a/install_opi5.sh
+++ b/install_opi5.sh
@@ -61,15 +61,10 @@ apt-get --yes -qq install libc6 libstdc++6
 # let netplan create the config during cloud-init
 rm -f /etc/netplan/00-default-nm-renderer.yaml
 
-mkdir --parents /mnt/CIDATA
-mount "${loopdev}p1" /mnt/CIDATA
 # set NetworkManager as the renderer in cloud-init
-cp -f ./OPi5_CIDATA/network-config /mnt/CIDATA/network-config
+cp -f ./OPi5_CIDATA/network-config /boot/network-config
 # add customized user-data file for cloud-init
-cp -f ./OPi5_CIDATA/user-data /mnt/CIDATA/user-data
-
-umount /mnt/CIDATA
-rmdir /mnt/CIDATA
+cp -f ./OPi5_CIDATA/user-data /boot/user-data
 
 # modify photonvision.service to enable big cores
 sed -i 's/# AllowedCPUs=4-7/AllowedCPUs=4-7/g' /lib/systemd/system/photonvision.service


### PR DESCRIPTION
photon-image-runner v1.2.0 has been updated to properly mount the /boot partition. This PR will write CIDATA files to this location on OPi5 images.

By using the updated runner, this also corrects a problem with the config.txt file not being copied to the correct location on RaspberryPi-based images.