### PR TITLE
Reuse install_pi.sh from install_limelight.sh and parametrize config.txt

### DIFF
--- a/install_limelight.sh
+++ b/install_limelight.sh
@@ -5,15 +5,12 @@ set -ex +u
 
 # Run the pi install script
 chmod +x ./install_pi.sh
-./install_pi.sh "$1"
+./install_pi.sh "$1" "limelight/config.txt"
 
 # mount partition 1 as /boot/firmware
 mkdir --parent /boot/firmware
 mount "${loopdev}p1" /boot/firmware
 ls -la /boot/firmware
-
-# Install our new config.txt with pwm overlay and ethernet config
-install -m 644 limelight/config.txt /boot/firmware/
 
 # link old config.txt location for diozero compatibility
 # TODO(thatcomputerguy0101): Remove this when diozero checks the new location

--- a/install_limelight.sh
+++ b/install_limelight.sh
@@ -3,25 +3,17 @@
 # Exit on errors, print commands, ignore unset variables
 set -ex +u
 
+# Run the pi install script
+chmod +x ./install_pi.sh
+./install_pi.sh "$1"
+
 # mount partition 1 as /boot/firmware
 mkdir --parent /boot/firmware
 mount "${loopdev}p1" /boot/firmware
 ls -la /boot/firmware
 
-# silence log spam from dpkg
-cat > /etc/apt/apt.conf.d/99dpkg.conf << EOF
-Dpkg::Progress-Fancy "0";
-APT::Color "0";
-Dpkg::Use-Pty "0";
-EOF
-
-# Run normal photon installer
-chmod +x ./install.sh
-./install.sh --install-nm=yes --arch=aarch64 --version="$1"
-
-# edit boot partition
+# Install our new config.txt with pwm overlay and ethernet config
 install -m 644 limelight/config.txt /boot/firmware/
-install -m 644 userconf.txt /boot/firmware/
 
 # link old config.txt location for diozero compatibility
 # TODO(thatcomputerguy0101): Remove this when diozero checks the new location
@@ -29,30 +21,5 @@ ln -sf /boot/firmware/config.txt /boot/config.txt
 
 # install LL DTS
 dtc -O dtb limelight/gloworm-dt.dts -o /boot/firmware/dt-blob.bin
-
-# Kill wifi and other networking things
-install -v -m 644 -D -t /etc/systemd/system/dhcpcd.service.d/ files/wait.conf
-install -v files/rpi-blacklist.conf /etc/modprobe.d/blacklist.conf
-
-# Enable ssh
-systemctl enable ssh
-
-# Remove extra packages too
-echo "Purging extra things"
-apt-get purge -y gdb gcc g++ linux-headers* libgcc*-dev libqt* wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek raspberrypi-net-mods
-apt-get autoremove -y
-
-echo "Installing additional things"
-sudo apt-get update
-apt-get install -y device-tree-compiler
-apt-get install -y network-manager net-tools
-# libcamera-driver stuff
-apt-get install -y libegl1 libopengl0 libgl1-mesa-dri libcamera-dev libgbm1
-
-rm -rf /var/lib/apt/lists/*
-apt-get clean
-
-rm -rf /usr/share/doc
-rm -rf /usr/share/locale/
 
 umount /boot/firmware

--- a/install_limelight3.sh
+++ b/install_limelight3.sh
@@ -5,15 +5,12 @@ set -ex +u
 
 # Run the pi install script
 chmod +x ./install_pi.sh
-./install_pi.sh "$1"
+./install_pi.sh "$1" "limelight3/config.txt"
 
 # mount partition 1 as /boot/firmware
 mkdir --parent /boot/firmware
 mount "${loopdev}p1" /boot/firmware
 ls -la /boot/firmware
-
-# Install our new config.txt with pwm overlay
-install -m 644 limelight3/config.txt /boot/firmware/
 
 # link old config.txt location for diozero compatibility
 # TODO(thatcomputerguy0101): Remove this when diozero checks the new location

--- a/install_limelight3g.sh
+++ b/install_limelight3g.sh
@@ -5,14 +5,4 @@ set -ex +u
 
 # Run the pi install script
 chmod +x ./install_pi.sh
-./install_pi.sh "$1"
-
-# mount partition 1 as /boot/firmware
-mkdir --parent /boot/firmware
-mount "${loopdev}p1" /boot/firmware
-ls -la /boot/firmware
-
-# Install our new config.txt with OV9281 overlay
-install -m 644 limelight3g/config.txt /boot/firmware
-
-umount /boot/firmware
+./install_pi.sh "$1" "limelight3g/config.txt"

--- a/install_limelight4.sh
+++ b/install_limelight4.sh
@@ -5,14 +5,4 @@ set -ex +u
 
 # Run the pi install script
 chmod +x ./install_pi.sh
-./install_pi.sh "$1"
-
-# mount partition 1 as /boot/firmware
-mkdir --parent /boot/firmware
-mount "${loopdev}p1" /boot/firmware
-ls -la /boot/firmware
-
-# Install our new config.txt with OV9281 overlay
-install -m 644 limelight4/config.txt /boot/firmware
-
-umount /boot/firmware
+./install_pi.sh "$1" "limelight4/config.txt"

--- a/install_luma_p1.sh
+++ b/install_luma_p1.sh
@@ -5,15 +5,12 @@ set -ex +u
 
 # Run the pi install script
 chmod +x ./install_pi.sh
-./install_pi.sh "$1"
+./install_pi.sh "$1" "luma_p1/config.txt"
 
 # mount partition 1 as /boot/firmware
 mkdir --parent /boot/firmware
 mount "${loopdev}p1" /boot/firmware
 ls -la /boot/firmware
-
-# Install our new config.txt with OV9281 overlay
-install -m 644 luma_p1/config.txt /boot/firmware
 
 # Add the database file for the p1 hardware config and default pipeline
 mkdir -p /opt/photonvision/photonvision_config

--- a/install_pi.sh
+++ b/install_pi.sh
@@ -20,7 +20,15 @@ chmod +x ./install.sh
 ./install.sh --install-nm=yes --arch=aarch64 --version="$1"
 
 # and edit boot partition
-install -m 644 config.txt /boot/firmware
+
+if [ -n "${2:-}" ]; then
+    config="$2"
+else
+    config="config.txt"
+fi
+
+
+install -m 644 $config /boot/firmware
 install -m 644 userconf.txt /boot/firmware
 
 # configure hostname


### PR DESCRIPTION
This removes the duplication in the limelight 2 install script by reusing the `install_pi.sh` script. Also, `config.txt` is now parameterized in `install_pi.sh` simplifying all the scripts that use it.