### PR TITLE
Pin photon-image-runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
         echo "$json_string" > image-version.json
 
     - name: Install dependencies and build image
-      uses: photonvision/photon-image-runner@HEAD
+      uses: photonvision/photon-image-runner@v1.3.0
       id: install_deps
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make sure that photon-image-runner points to v1.3.0 so that changes to the runner don't break the image builder. There is a breaking change in https://github.com/PhotonVision/photon-image-runner/pull/8 that may cause problems for this workflow if it is merged to main.