### PR TITLE
remove old image version file

### DIFF
--- a/install_common.sh
+++ b/install_common.sh
@@ -33,8 +33,4 @@ echo "Banner /etc/issue.net" > /etc/ssh/sshd_config.d/90_PhotonVisionBanner.conf
 # Add photon version file
 mkdir -p /opt/photonvision/
 
-# Keep this for legacy purposes
-# DEPRECATED: removal in 2027
-echo "${GITHUB_REF_NAME};${image_name}" > /opt/photonvision/image-version
-
 cp -f ./image-version.json /opt/photonvision/image-version.json


### PR DESCRIPTION
This old image_version file was retained for backwards compat, we now use a new file that consists of a json with more information.

See https://github.com/PhotonVision/photonvision/commit/f821657d2b7cd41527c7615013bc98e48535717d for the upstream usage.