### PR TITLE
install packages for npu metrics

### DIFF
--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -103,6 +103,9 @@ apt-get autoremove --yes
 rm /usr/sbin/update-grub
 dpkg-divert --local --rename --remove /usr/sbin/update-grub
 
+# Patch grub-mkconfig
+sed -i 's|GRUB_DEVICE="`${grub_probe} --target=device /`"|GRUB_DEVICE="${GRUB_DEVICE:-`${grub_probe} --target=device /`}"|' /usr/sbin/grub-mkconfig
+
 # Run update-grub with proper config
 GRUB_DEVICE=UUID=$(blkid -s UUID -o value ${rootdev}) update-grub
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -84,9 +84,22 @@ apt-get clean
 
 df -h /dev/loop0
 
+# Divert grub update script
+dpkg-divert --local --rename --add /usr/sbin/update-grub
+cat > /usr/sbin/update-grub << 'EOF'
+#!/bin/sh
+echo "update-grub suppressed while we're in the chroot"
+exit 0
+EOF
+chmod +x /usr/sbin/update-grub
+
 # qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
 apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
+# Remove the old kernel
+apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
 
+# Remove the update-grub divert
+dpkg-divert --local --rename --remove /usr/sbin/update-grub
 
 # Download packages for installing NPU metrics daemon
 curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"
@@ -113,7 +126,6 @@ hostname: photonvision
 
 runcmd:
 - nmcli radio all off
-- update-grub
 - touch /etc/cloud/cloud-init.disabled
 EOFUSERDATA
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -97,6 +97,7 @@ chmod +x /usr/sbin/update-grub
 apt-get -y install qcom-fastrpc1 linux-image-qcom=6.8.0-1077.81
 # Remove the old kernel
 apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
+apt-get autoremove --yes
 
 # Remove the update-grub divert
 rm /usr/sbin/update-grub
@@ -183,10 +184,6 @@ rm -rf /var/lib/apt/lists/*
 df -h /dev/loop0
 
 apt-get clean
-df -h /dev/loop0
-
-# this should remove the old kernel
-apt-get autoremove --yes
 df -h /dev/loop0
 
 rm -rf /usr/share/doc

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -85,7 +85,10 @@ apt-get clean
 df -h /dev/loop0
 
 # qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
-apt-get -y install qcom-fastrpc1 # linux-image-6.8.0-1071-qcom
+apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
+# after upgrading the kernel, we need to update grub
+update-grub
+
 
 # Download packages for installing NPU metrics daemon
 curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"
@@ -165,6 +168,10 @@ rm -rf /var/lib/apt/lists/*
 df -h /dev/loop0
 
 apt-get clean
+df -h /dev/loop0
+
+# this should remove the old kernel
+apt-get autoremove --yes
 df -h /dev/loop0
 
 rm -rf /usr/share/doc

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -8,6 +8,9 @@ echo '=== Current directory: $(pwd) ==='
 echo '=== Files in current directory: ==='
 ls -la
 
+echo "kernel version"
+uname -r
+
 # This fixes log spam from iris_vpu AKA msm_vidc
 # See: https://github.com/rubikpi-ai/linux-debian/blob/0f0155ba6d6057a6a86162597f48c24e1a54d1a1/ubuntu/qcom/video/vidc/inc/msm_vidc_debug.h#L101
 # and https://github.com/rubikpi-ai/linux-debian/blob/0f0155ba6d6057a6a86162597f48c24e1a54d1a1/ubuntu/qcom/video/vidc/src/msm_vidc_debug.c#L25
@@ -75,39 +78,7 @@ df -h /dev/loop0
 
 # Install packages from the RUBIK Pi PPA, we skip calling apt-get update here because install.sh already does that
 # libqnn1, libsnpe1, and qcom-adreno1 are for OD
-apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler
-
-# We do an apt clean in between installing packages as we don't have enough space otherwise
-df -h /dev/loop0
-
-apt-get clean
-
-df -h /dev/loop0
-
-# Divert grub update script
-dpkg-divert --local --rename --add /usr/sbin/update-grub
-cat > /usr/sbin/update-grub << 'EOF'
-#!/bin/sh
-echo "update-grub suppressed while we're in the chroot"
-exit 0
-EOF
-chmod +x /usr/sbin/update-grub
-
-# qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
-apt-get -y install qcom-fastrpc1 linux-image-qcom=6.8.0-1077.81
-# Remove the old kernel
-apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
-apt-get autoremove --yes
-
-# Remove the update-grub divert
-rm /usr/sbin/update-grub
-dpkg-divert --local --rename --remove /usr/sbin/update-grub
-
-# Patch grub-mkconfig
-sed -i 's|GRUB_DEVICE="`${grub_probe} --target=device /`"|GRUB_DEVICE="${GRUB_DEVICE:-`${grub_probe} --target=device /`}"|' /usr/sbin/grub-mkconfig
-
-# Run update-grub with proper config
-GRUB_DEVICE=UUID=$(blkid -s UUID -o value ${rootdev}) update-grub
+apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler qcom-fastrpc1
 
 # Download packages for installing NPU metrics daemon
 curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -85,7 +85,7 @@ apt-get clean
 df -h /dev/loop0
 
 # qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
-apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
+apt-get -y install qcom-fastrpc1 # linux-image-6.8.0-1071-qcom
 
 # Download packages for installing NPU metrics daemon
 curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -66,8 +66,32 @@ df -h
 chmod +x ./install.sh
 ./install.sh --control-networking=yes --arch=aarch64 --version="$1"
 
+# We do an apt clean in between installing packages as we don't have enough space otherwise
+df -h /dev/loop0
+
+apt-get clean
+
+df -h /dev/loop0
+
 # Install packages from the RUBIK Pi PPA, we skip calling apt-get update here because install.sh already does that
+# libqnn1, libsnpe1, and qcom-adreno1 are for OD
 apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler
+
+# We do an apt clean in between installing packages as we don't have enough space otherwise
+df -h /dev/loop0
+
+apt-get clean
+
+df -h /dev/loop0
+
+# qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
+apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
+
+# Download packages for installing NPU metrics daemon
+curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"
+
+dpkg -i metrics-daemon/*.deb
+rm -rf metrics-daemon
 
 # Enable ssh
 systemctl enable ssh

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -99,6 +99,7 @@ apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
 apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
 
 # Remove the update-grub divert
+rm /usr/sbin/update-grub
 dpkg-divert --local --rename --remove /usr/sbin/update-grub
 
 # Run update-grub with proper config

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -8,9 +8,6 @@ echo '=== Current directory: $(pwd) ==='
 echo '=== Files in current directory: ==='
 ls -la
 
-echo "kernel version"
-uname -r
-
 # This fixes log spam from iris_vpu AKA msm_vidc
 # See: https://github.com/rubikpi-ai/linux-debian/blob/0f0155ba6d6057a6a86162597f48c24e1a54d1a1/ubuntu/qcom/video/vidc/inc/msm_vidc_debug.h#L101
 # and https://github.com/rubikpi-ai/linux-debian/blob/0f0155ba6d6057a6a86162597f48c24e1a54d1a1/ubuntu/qcom/video/vidc/src/msm_vidc_debug.c#L25
@@ -69,15 +66,8 @@ df -h
 chmod +x ./install.sh
 ./install.sh --control-networking=yes --arch=aarch64 --version="$1"
 
-# We do an apt clean in between installing packages as we don't have enough space otherwise
-df -h /dev/loop0
-
-apt-get clean
-
-df -h /dev/loop0
-
 # Install packages from the RUBIK Pi PPA, we skip calling apt-get update here because install.sh already does that
-# libqnn1, libsnpe1, and qcom-adreno1 are for OD
+# libqnn1, libsnpe1, and qcom-adreno1 are for OD, qcom-fastrpc1 is for npu metrics
 apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler qcom-fastrpc1
 
 # Download packages for installing NPU metrics daemon

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -86,8 +86,6 @@ df -h /dev/loop0
 
 # qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
 apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
-# after upgrading the kernel, we need to update grub
-update-grub
 
 
 # Download packages for installing NPU metrics daemon
@@ -115,6 +113,7 @@ hostname: photonvision
 
 runcmd:
 - nmcli radio all off
+- update-grub
 - touch /etc/cloud/cloud-init.disabled
 EOFUSERDATA
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -94,7 +94,7 @@ EOF
 chmod +x /usr/sbin/update-grub
 
 # qcom-fastrpc1 and linux-image-6.8.0-1071-qcom are for NPU metrics
-apt-get -y install qcom-fastrpc1 linux-image-6.8.0-1071-qcom
+apt-get -y install qcom-fastrpc1 linux-image-qcom=6.8.0-1077.81
 # Remove the old kernel
 apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -101,6 +101,9 @@ apt-get -y purge linux-image-6.8.0-1055-qcom linux-modules-6.8.0-1055-qcom
 # Remove the update-grub divert
 dpkg-divert --local --rename --remove /usr/sbin/update-grub
 
+# Run update-grub with proper config
+GRUB_DEVICE=UUID=$(blkid -s UUID -o value ${rootdev}) update-grub
+
 # Download packages for installing NPU metrics daemon
 curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -77,9 +77,9 @@ DEBPOOL=https://deb.debian.org/debian/pool/contrib
 
 curl --output-dir metrics-daemon -O "${DEBPOOL}/f/fastrpc/libfastrpc1_1.0.2-2_arm64.deb"
 curl --output-dir metrics-daemon -O "${DEBPOOL}/libq/libqcnpuperf/libqcnpuperf1_1.0.0-1_arm64.deb"
-curl --output-dir metrics-daemon -O "https://github.com/samfreund/qcnpuperfmon/releases/download/0.0.1/qcnpuperfd_1.0.0-1_arm64.deb"
+curl -L --output-dir metrics-daemon -O "https://github.com/samfreund/qcnpuperfmon/releases/download/0.0.1/qcnpuperfd_1.0.0-1_arm64.deb"
 
-dpkg -i metrics-daemon/*.deb
+dpkg -i --force-overwrite metrics-daemon/*.deb
 rm -rf metrics-daemon
 
 # Enable ssh

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -77,7 +77,7 @@ DEBPOOL=https://deb.debian.org/debian/pool/contrib
 
 curl --output-dir metrics-daemon -O "${DEBPOOL}/f/fastrpc/libfastrpc1_1.0.2-2_arm64.deb"
 curl --output-dir metrics-daemon -O "${DEBPOOL}/libq/libqcnpuperf/libqcnpuperf1_1.0.0-1_arm64.deb"
-curl -L --output-dir metrics-daemon -O "https://github.com/samfreund/qcnpuperfmon/releases/download/0.0.1/qcnpuperfd_1.0.0-1_arm64.deb"
+curl -L --output-dir metrics-daemon -O "https://github.com/samfreund/qcnpuperfmon/releases/download/dev/qcnpuperfd_1.0.0-1_arm64.deb"
 
 dpkg -i --force-overwrite metrics-daemon/*.deb
 rm -rf metrics-daemon

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -67,8 +67,8 @@ chmod +x ./install.sh
 ./install.sh --control-networking=yes --arch=aarch64 --version="$1"
 
 # Install packages from the RUBIK Pi PPA, we skip calling apt-get update here because install.sh already does that
-# libqnn1, libsnpe1, and qcom-adreno1 are for OD, qcom-fastrpc1 is for npu metrics
-apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler qcom-fastrpc1
+# libqnn1, libsnpe1, and qcom-adreno1 are for OD
+apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler
 
 # Download packages for installing NPU metrics daemon
 mkdir metrics-daemon

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -71,7 +71,13 @@ chmod +x ./install.sh
 apt-get -y install libqnn1 libsnpe1 qcom-adreno1 device-tree-compiler qcom-fastrpc1
 
 # Download packages for installing NPU metrics daemon
-curl -fL --create-dirs --output-dir metrics-daemon/ -O "https://github.com/samfreund-qc/libqcnpuperf/releases/download/v1.0.1/{qcnpuperfd_1.0-1_arm64.deb,libqcnpuperf1_1.0-1_arm64.deb}"
+mkdir metrics-daemon
+
+DEBPOOL=https://deb.debian.org/debian/pool/contrib
+
+curl --output-dir metrics-daemon -O "${DEBPOOL}/f/fastrpc/libfastrpc1_1.0.2-2_arm64.deb"
+curl --output-dir metrics-daemon -O "${DEBPOOL}/libq/libqcnpuperf/libqcnpuperf1_1.0.0-1_arm64.deb"
+curl --output-dir metrics-daemon -O "https://github.com/samfreund/qcnpuperfmon/releases/download/0.0.1/qcnpuperfd_1.0.0-1_arm64.deb"
 
 dpkg -i metrics-daemon/*.deb
 rm -rf metrics-daemon


### PR DESCRIPTION
Qualcomm is publishing https://tracker.debian.org/pkg/libqcnpuperf and we're just gonna roll our own daemon.

I'm going to leave this branch as draft until libqcnpuperf is available from the ppa.