### PR TITLE
Test shrinking OPi5 Armbian image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
             script: ./install_opi5_armbian.sh
             base_image: https://armbian.hosthatch.com/archive/orangepi5/archive/Armbian_26.2.1_Orangepi5_trixie_vendor_6.1.115_minimal.img.xz
             root_location: "partition=1"
-            shrink_image: "no"
+            shrink_image: 'yes'
 
     name: "Build for ${{ matrix.name }}"
 


### PR DESCRIPTION
On the Armbian Trixie distro, `parted` seems to be behaving differently during image compression. This PR is for figuring out how to fix it.