### PR TITLE
Rubik 26.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
 
   release:
     needs: [build]
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
       # Download literally every single artifact
       - uses: actions/download-artifact@v8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
 
   release:
     needs: [build]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       # Download literally every single artifact
       - uses: actions/download-artifact@v8

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -45,28 +45,28 @@ echo "=== Space after pre-cleanup ==="
 df -h
 
 # Pre-configure grub to avoid interactive prompts in chroot
-sudo debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices multiselect"
-sudo debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices_empty boolean true"
+debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices multiselect"
+debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices_empty boolean true"
 
 # Upgrade from 24.04 to 26.04 via direct dist-upgrade
 # More space-efficient than do-release-upgrade (doesn't keep old packages)
-sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
-sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list 2>/dev/null || true
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade || true
-DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade || true
+sed -i 's/noble/resolute/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+sed -i 's/noble/resolute/g' /etc/apt/sources.list 2>/dev/null || true
+DEBIAN_FRONTEND=noninteractive apt-get -y update
+DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade || true
+DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade || true
 # Remove dragonwing initramfs hook that fails in chroot
-sudo rm -f /usr/share/initramfs-tools/hooks/linux-firmware-dragonwing
+rm -f /usr/share/initramfs-tools/hooks/linux-firmware-dragonwing
 # Fix dpkg state after upgrade (some pkg configs fail in chroot)
-sudo dpkg --configure -a 2>/dev/null || true
-sudo apt-get --fix-broken install -y 2>/dev/null || true
+dpkg --configure -a 2>/dev/null || true
+apt-get --fix-broken install -y 2>/dev/null || true
 # Regenerate grub.cfg now that the kernel/initramfs are actually in place
 # (the kernel postinst ran before the initramfs existed, so grub.cfg has no entries)
-sudo update-grub 2>/dev/null || true
-sudo apt autoremove --purge -y
+update-grub 2>/dev/null || true
+apt autoremove --purge -y
 # Remove old 24.04 kernels, keep the new 26.04 one(s)
-dpkg -l | awk '/^ii.*linux-(image|headers|modules)/{print $2}' | sort -V | head -n -1 | xargs sudo apt-get purge --yes 2>/dev/null || true
-sudo apt-get clean
+dpkg -l | awk '/^ii.*linux-(image|headers|modules)/{print $2}' | sort -V | head -n -1 | xargs apt-get purge --yes 2>/dev/null || true
+apt-get clean
 
 echo "=== Space after upgrade ==="
 df -h

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -24,6 +24,10 @@ rm -rf /usr/share/locale/
 echo "=== Space after pre-cleanup ==="
 df -h
 
+# Pre-configure grub to avoid interactive prompts in chroot
+sudo debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices multiselect"
+sudo debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices_empty boolean true"
+
 # Upgrade from 24.04 to 26.04 via direct dist-upgrade
 # More space-efficient than do-release-upgrade (doesn't keep old packages)
 sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -29,8 +29,11 @@ df -h
 sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list 2>/dev/null || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade
-DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade
+DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade || true
+DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade || true
+# Fix dpkg state after upgrade (some pkg configs fail in chroot)
+sudo dpkg --configure -a 2>/dev/null || true
+sudo apt-get --fix-broken install -y 2>/dev/null || true
 sudo apt autoremove --purge -y
 sudo apt-get clean
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
 
+echo "=== Pre-upgrade space ==="
+df -h
+
+# Free up space BEFORE upgrading, so the dist-upgrade has room to work
+# get rid of snap seeds
+rm -rf /var/lib/snapd/seed/snaps/* 2>/dev/null || true
+rm -f /var/lib/snapd/seed/seed.yaml 2>/dev/null || true
+
+# Remove packages that waste space and aren't needed in the final image
+apt-get purge --yes lxd-installer lxd-agent-loader snapd gdb gcc g++ linux-headers* libgcc*-dev perl-modules* git vim-runtime python3-twisted bluez 2>/dev/null || true
+
+# Remove packages that conflict with the 26.04 upgrade
+apt-get remove --yes libgstreamer-qcom1.0-0 sosreport 2>/dev/null || true
+
+apt-get autoremove --purge -y
+rm -rf /var/lib/apt/lists/*
+apt-get clean
+
+rm -rf /usr/share/doc
+rm -rf /usr/share/locale/
+
+echo "=== Space after pre-cleanup ==="
+df -h
+
 # Upgrade from 24.04 to 26.04 via direct dist-upgrade
 # More space-efficient than do-release-upgrade (doesn't keep old packages)
 sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
 sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list 2>/dev/null || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y upgrade
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y dist-upgrade
+DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade
+DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade
 sudo apt autoremove --purge -y
 sudo apt-get clean
+
+echo "=== Space after upgrade ==="
+df -h
 
 # Exit on errors, print commands, ignore unset variables
 set -ex +u
@@ -56,11 +83,6 @@ wget -qO - https://thundercomm.s3.dualstack.ap-northeast-1.amazonaws.com/uploads
 echo "Space available before purging things"
 df -h
 
-# get rid of snaps
-echo "Purging snaps"
-rm -rf /var/lib/snapd/seed/snaps/*
-rm -f /var/lib/snapd/seed/seed.yaml
-apt-get purge --yes lxd-installer lxd-agent-loader snapd gdb gcc g++ linux-headers* libgcc*-dev perl-modules* git vim-runtime python3-twisted sosreport bluez
 apt-get autoremove --yes
 
 rm -rf /var/lib/apt/lists/*
@@ -144,15 +166,11 @@ EOF_FAN_SERVICE
 # 4. Enable the new service
 systemctl enable rubik-fan-max.service
 
-echo "Space available before purging things"
-df -h /dev/loop0
+echo "Space available before final cleanup"
+df -h
 
 rm -rf /var/lib/apt/lists/*
-df -h /dev/loop0
-
 apt-get clean
-df -h /dev/loop0
-
 rm -rf /usr/share/doc
 rm -rf /usr/share/locale/
 
@@ -162,5 +180,5 @@ rm -rf /usr/lib/firmware/mellanox
 rm -rf /usr/lib/firmware/nvidia
 rm -rf /usr/lib/firmware/intel
 
-echo "Space available after purging things"
-df -h /dev/loop0
+echo "Space available after final cleanup"
+df -h

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -30,8 +30,8 @@ sudo debconf-set-selections <<< "grub-efi-arm64 grub-efi/install_devices_empty b
 
 # Upgrade from 24.04 to 26.04 via direct dist-upgrade
 # More space-efficient than do-release-upgrade (doesn't keep old packages)
-sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
-sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list 2>/dev/null || true
+sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+sudo sed -i 's/noble/resolute/g' /etc/apt/sources.list 2>/dev/null || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
 DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade || true
@@ -76,7 +76,7 @@ EOF_DPKG
 cat > /etc/apt/sources.list.d/ubuntu.sources << EOF_UBUNTU_SOURCES
 Types: deb
 URIs: http://ports.ubuntu.com/ubuntu-ports
-Suites: plucky plucky-updates plucky-backports
+Suites: resolute resolute-updates resolute-backports
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF_UBUNTU_SOURCES

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -104,9 +104,6 @@ EOF_UBUNTU_SOURCES
 
 apt-get -q update
 
-# This needs to run before install.sh to fix some weird dependency issues
-apt-get -y install libsqlite3-0
-
 # Add the GPG key for the RUBIK Pi PPA
 wget -qO - https://thundercomm.s3.dualstack.ap-northeast-1.amazonaws.com/uploads/web/rubik-pi-3/tools/key.asc | tee /etc/apt/trusted.gpg.d/rubikpi3.asc
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -1,3 +1,6 @@
+# Exit on errors, print commands, ignore unset variables
+set -ex +u
+
 #!/bin/bash
 
 echo "=== Pre-upgrade space ==="
@@ -65,9 +68,6 @@ sudo apt-get clean
 
 echo "=== Space after upgrade ==="
 df -h
-
-# Exit on errors, print commands, ignore unset variables
-set -ex +u
 
 cd /tmp/build
 echo '=== Current directory: $(pwd) ==='

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
+
 # Exit on errors, print commands, ignore unset variables
 set -ex +u
-
-#!/bin/bash
 
 echo "=== Pre-upgrade space ==="
 df -h

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Start by upgrading to 26.04 (please release a 26.04 image variant Qualcomm :pray:)
-sudo apt update && sudo apt upgrade -y
-sudo apt dist-upgrade -y
-sudo apt autoremove -y   
-
-sudo sed -i 's/Prompt=.*/Prompt=lts/' /etc/update-manager/release-upgrades
-
-sudo do-release-upgrade --frontend=DistUpgradeViewNonInteractive
+# Upgrade from 24.04 to 26.04 via direct dist-upgrade
+# More space-efficient than do-release-upgrade (doesn't keep old packages)
+sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list 2>/dev/null || true
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y upgrade
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y dist-upgrade
+sudo apt autoremove --purge -y
+sudo apt-get clean
 
 # Exit on errors, print commands, ignore unset variables
 set -ex +u
@@ -36,7 +37,7 @@ EOF_DPKG
 cat > /etc/apt/sources.list.d/ubuntu.sources << EOF_UBUNTU_SOURCES
 Types: deb
 URIs: http://ports.ubuntu.com/ubuntu-ports
-Suites: noble noble-updates noble-backports
+Suites: plucky plucky-updates plucky-backports
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF_UBUNTU_SOURCES
@@ -46,7 +47,7 @@ EOF_UBUNTU_SOURCES
 apt-get -q update
 
 # This needs to run before install.sh to fix some weird dependency issues
-apt-get -y --allow-downgrades install libsqlite3-0=3.45.1-1ubuntu2
+apt-get -y install libsqlite3-0
 
 # Add the GPG key for the RUBIK Pi PPA
 wget -qO - https://thundercomm.s3.dualstack.ap-northeast-1.amazonaws.com/uploads/web/rubik-pi-3/tools/key.asc | tee /etc/apt/trusted.gpg.d/rubikpi3.asc

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -35,6 +35,8 @@ sudo sed -i 's/noble/plucky/g' /etc/apt/sources.list 2>/dev/null || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
 DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y upgrade || true
 DEBIAN_FRONTEND=noninteractive sudo apt-get -o Dpkg::Options::="--force-overwrite" -y dist-upgrade || true
+# Remove dragonwing initramfs hook that fails in chroot
+sudo rm -f /usr/share/initramfs-tools/hooks/linux-firmware-dragonwing
 # Fix dpkg state after upgrade (some pkg configs fail in chroot)
 sudo dpkg --configure -a 2>/dev/null || true
 sudo apt-get --fix-broken install -y 2>/dev/null || true

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -40,6 +40,9 @@ sudo rm -f /usr/share/initramfs-tools/hooks/linux-firmware-dragonwing
 # Fix dpkg state after upgrade (some pkg configs fail in chroot)
 sudo dpkg --configure -a 2>/dev/null || true
 sudo apt-get --fix-broken install -y 2>/dev/null || true
+# Regenerate grub.cfg now that the kernel/initramfs are actually in place
+# (the kernel postinst ran before the initramfs existed, so grub.cfg has no entries)
+sudo update-grub 2>/dev/null || true
 sudo apt autoremove --purge -y
 sudo apt-get clean
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -64,6 +64,8 @@ sudo apt-get --fix-broken install -y 2>/dev/null || true
 # (the kernel postinst ran before the initramfs existed, so grub.cfg has no entries)
 sudo update-grub 2>/dev/null || true
 sudo apt autoremove --purge -y
+# Remove old 24.04 kernels, keep the new 26.04 one(s)
+dpkg -l | awk '/^ii.*linux-(image|headers|modules)/{print $2}' | sort -V | head -n -1 | xargs sudo apt-get purge --yes 2>/dev/null || true
 sudo apt-get clean
 
 echo "=== Space after upgrade ==="

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Start by upgrading to 26.04 (please release a 26.04 image variant Qualcomm :pray:)
+sudo apt update && sudo apt upgrade -y
+sudo apt dist-upgrade -y
+sudo apt autoremove -y   
+
+sudo sed -i 's/Prompt=.*/Prompt=lts/' /etc/update-manager/release-upgrades
+
+sudo do-release-upgrade --frontend=DistUpgradeViewNonInteractive
+
 # Exit on errors, print commands, ignore unset variables
 set -ex +u
 

--- a/install_rubikpi3.sh
+++ b/install_rubikpi3.sh
@@ -11,6 +11,13 @@ rm -f /var/lib/snapd/seed/seed.yaml 2>/dev/null || true
 # Remove packages that waste space and aren't needed in the final image
 apt-get purge --yes lxd-installer lxd-agent-loader snapd gdb gcc g++ linux-headers* libgcc*-dev perl-modules* git vim-runtime python3-twisted bluez 2>/dev/null || true
 
+# Remove filesystem/RAID/crypto tools not needed on the rubikpi3 (ext4 root).
+# This also shrinks the 26.04 dracut/initramfs by skipping their hooks.
+apt-get purge --yes btrfs-progs lvm2 cryptsetup cryptsetup-initramfs mdadm multipath-tools open-iscsi 2>/dev/null || true
+
+# Remove misc services not needed on a headless vision appliance
+apt-get purge --yes fwupd apport ubuntu-advantage-tools landscape-common motd-news-config friendly-recovery command-not-found plymouth bolt cups alsa-utils 2>/dev/null || true
+
 # Remove packages that conflict with the 26.04 upgrade
 apt-get remove --yes libgstreamer-qcom1.0-0 sosreport 2>/dev/null || true
 
@@ -20,6 +27,16 @@ apt-get clean
 
 rm -rf /usr/share/doc
 rm -rf /usr/share/locale/
+
+# Remove firmware for hardware that the rubikpi3 definitely doesn't have
+rm -rf /usr/lib/firmware/mrvl
+rm -rf /usr/lib/firmware/mellanox
+rm -rf /usr/lib/firmware/nvidia
+rm -rf /usr/lib/firmware/intel
+rm -rf /usr/lib/firmware/amd
+rm -rf /usr/lib/firmware/amdgpu
+rm -rf /usr/lib/firmware/i915
+rm -rf /usr/lib/firmware/radeon
 
 echo "=== Space after pre-cleanup ==="
 df -h


### PR DESCRIPTION
Because wpilib is now building on trixie, we need a later glibc version. Since QC hasn't released a 26.04 image yet, we're going to use this one as a shim for testing.